### PR TITLE
Add appveyor CI config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # EventBus [![GitHub version](https://badge.fury.io/gh/gelldur%2FEventBus.svg)](https://badge.fury.io/gh/gelldur%2FEventBus)
 &nbsp;&nbsp;[![Build status for Travis](https://travis-ci.org/gelldur/EventBus.svg?branch=master)](https://travis-ci.org/gelldur/EventBus)
-&nbsp;&nbsp;[![Build status for Appveyor](https://ci.appveyor.com/api/projects/status/github/gelldur/EventBus)](https://ci.appveyor.com/project/gelldur/EventBus)
+&nbsp;&nbsp;[![Build status for Appveyor](https://ci.appveyor.com/api/projects/status/s463l4o3rhegtx00?svg=true)](https://ci.appveyor.com/project/gelldur/EventBus)
 
 Simple and very fast event bus.
 The EventBus library is a convenient realization of the observer pattern.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,61 @@
+version: build-{build}
+image: Visual Studio 2017
+configuration:
+  - Release
+  - Debug
+
+platform:
+  - x64
+
+cache: C:/Users/appveyor/.local
+
+install:
+- cmd: >-
+    pwd
+
+    rm -rf .cache
+
+    mkdir -p .cache
+
+    cd .cache
+
+    curl -L https://github.com/catchorg/Catch2/archive/v2.3.0.zip --output Catch2-v2.3.0.zip
+
+    7z x Catch2-v2.3.0.zip  && cd Catch2-2.3.0
+
+    mkdir -p build && cd build
+
+    cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=%CONFIGURATION% -DCMAKE_INSTALL_PREFIX=~/.local/ .. && cmake --build . --target install --config %CONFIGURATION%
+
+    cd ../../..
+
+    pwd
+nuget:
+  disable_publish_on_pr: true
+  disable_publish_octopus: true
+
+build_script:
+- cmd: >-
+    cd lib
+
+    mkdir build-%CONFIGURATION% && cd build-%CONFIGURATION%
+
+    pwd
+
+    cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=%CONFIGURATION% -DCMAKE_INSTALL_PREFIX=~/.local .. && cmake --build . --target install --config %CONFIGURATION%
+
+    cd ../..
+
+    pwd
+
+test_script:
+- cmd: >-
+    cd test
+
+    mkdir build-%CONFIGURATION% && cd build-%CONFIGURATION%
+
+    cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=%CONFIGURATION% -DCMAKE_INSTALL_PREFIX=~/.local/ .. && cmake --build . --config %CONFIGURATION% && ctest -C %CONFIGURATION% -V .
+
+    cd ../..
+
+    pwd

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,13 +25,13 @@ add_executable(EventBusTest
 	src/NotifierTest.cpp
 	)
 
-target_compile_options(EventBusTest PUBLIC
-		-Wall -pedantic
-		-Wno-unused-private-field
-		-Wnon-virtual-dtor
-		-Wno-gnu
-		-Werror
-		)
+#target_compile_options(EventBusTest PUBLIC
+#		-Wall -pedantic
+#		-Wno-unused-private-field
+#		-Wnon-virtual-dtor
+#		-Wno-gnu
+#		-Werror
+#		)
 
 # Don't do such thing:
 # if(CMAKE_BUILD_TYPE STREQUAL DEBUG)
@@ -44,11 +44,11 @@ target_compile_options(EventBusTest PUBLIC
 # target_compile_definitions(foo PRIVATE "VERBOSITY=$<IF:$<BOOL:${VERBOSE}>,30,10>")
 
 
-set(EVENTBUS_DEBUG_FLAGS
-		-O0 -fno-inline
-		-DDEBUG
-		#-D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC
-		)
+#set(EVENTBUS_DEBUG_FLAGS
+#		-O0 -fno-inline
+#		-DDEBUG
+#		#-D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC
+#		)
 
 target_compile_options(EventBusTest PUBLIC "$<$<CONFIG:DEBUG>:${EVENTBUS_DEBUG_FLAGS}>")
 

--- a/test/src/AsyncEventBusTest.cpp
+++ b/test/src/AsyncEventBusTest.cpp
@@ -73,7 +73,7 @@ TEST_CASE("Should unlisten for event When call unlisten inside Listener", "[Asyn
 
 	const int myToken = 0x23167;
 
-	bus.listen<SimpleEvent>(myToken, [&counter, &bus](const SimpleEvent& event)
+	bus.listen<SimpleEvent>(myToken, [&counter, &bus, myToken](const SimpleEvent& event)
 	{
 		std::cout << "Event from: " << event.id << std::endl;
 		++counter;
@@ -108,7 +108,7 @@ TEST_CASE("Should listen for only 1 event When call unlisten inside Listener", "
 
 	const int myToken = 0x23167;
 
-	bus.listen<SimpleEvent>(myToken, [&counter, &bus](const SimpleEvent& event)
+	bus.listen<SimpleEvent>(myToken, [&counter, &bus, myToken](const SimpleEvent& event)
 	{
 		std::cout << "Event from: " << event.id << std::endl;
 		++counter;


### PR DESCRIPTION
Each line in `- cmd: >-` needs extra new line (why?)

For now disable some flags that do not work for Visual Studio

Fix tests for Visual Studio

Resolving issue: #2 