### PR TITLE
Fix compile on debian buster

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -10,7 +10,7 @@ project(EventBus
 	)
 
 # Dependencies
-# No dependencies for EventBus yay!
+find_package(Threads)
 
 # Introduce variables:
 # * CMAKE_INSTALL_LIBDIR
@@ -18,7 +18,6 @@ project(EventBus
 # * CMAKE_INSTALL_INCLUDEDIR
 include(GNUInstallDirs)
 include(cmake/InstallHelp.cmake)
-
 
 # Layout. This works for all platforms:
 #   * <prefix>/lib*/cmake/<PROJECT-NAME>
@@ -71,6 +70,7 @@ target_include_directories(EventBus PUBLIC
 	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/>
 	$<INSTALL_INTERFACE:include/>
 	)
+target_link_libraries(EventBus ${CMAKE_THREAD_LIBS_INIT})
 
 # Add definitions for targets
 # Values:


### PR DESCRIPTION
On debian buster with gcc 8.3 I see the following compiler error:

```
[build] FAILED: 3rdparty/eventbus/use_case/basic/UseCase_Basic 
[build] : && /bin/g++-8  -DTORRENT_NO_DEPRECATE=1 -DSPDLOG_FMT_EXTERNAL=1 -DJSONCONS_HAS_OPTIONAL=1 -DNO_BOOST_SERIALIZATION=1 -DGSL_THROW_ON_CONTRACT_VIOLATION -DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO -g   3rdparty/eventbus/use_case/basic/CMakeFiles/UseCase_Basic.dir/src/main.cpp.o  -o 3rdparty/eventbus/use_case/basic/UseCase_Basic  3rdparty/eventbus/lib/libEventBus.a && :
[build] /usr/bin/ld: 3rdparty/eventbus/use_case/basic/CMakeFiles/UseCase_Basic.dir/src/main.cpp.o: in function `std::__shared_mutex_pthread::lock()':
[build] /usr/include/c++/8/shared_mutex:103: undefined reference to `pthread_rwlock_wrlock'
[build] /usr/bin/ld: 3rdparty/eventbus/use_case/basic/CMakeFiles/UseCase_Basic.dir/src/main.cpp.o: in function `std::__shared_mutex_pthread::unlock()':
[build] /usr/include/c++/8/shared_mutex:123: undefined reference to `pthread_rwlock_unlock'
[build] /usr/bin/ld: 3rdparty/eventbus/lib/libEventBus.a(EventBus.cpp.o): in function `std::__shared_mutex_pthread::lock_shared()':
[build] /usr/include/c++/8/shared_mutex:139: undefined reference to `pthread_rwlock_rdlock'
[build] collect2: error: ld returned 1 exit status
```

This adds threads to the linker arguments.