### PR TITLE
Fix weird MSVC errors

### DIFF
--- a/lib/src/dexode/EventBus.cpp
+++ b/lib/src/dexode/EventBus.cpp
@@ -30,7 +30,7 @@ std::size_t EventBus::processLimit(const std::size_t limit)
 
 	{
 		std::lock_guard writeGuard{_mutexStreams};
-		if(not _eventStreams.empty())
+		if(!_eventStreams.empty())
 		{
 			// If anything was added then we need to add those elements
 			std::move(_eventStreams.begin(), _eventStreams.end(), std::back_inserter(eventStreams));

--- a/lib/src/dexode/EventBus.hpp
+++ b/lib/src/dexode/EventBus.hpp
@@ -8,6 +8,7 @@
 #include <map>
 #include <memory>
 #include <shared_mutex>
+#include <iterator>
 
 #include "dexode/eventbus/Bus.hpp"
 


### PR DESCRIPTION
I am not sure if this was caused by the code itself or some mistake I made during building but I followed every step according to the README but always got to an entire mass of weird, illegogical errors. Apparently, the core problem was that the `not` keyword isn't defined in MSVC. Another issue was that it couldn't find `std::back_inserter` (I already addressed that in #41 ).

Errors without the changes:
[dump.txt](https://github.com/gelldur/EventBus/files/6722374/dump.txt)
