### PR TITLE
Some fixes for MSVC 2019

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,8 +79,8 @@ set(CMAKE_CXX_FLAGS_UBSAN
 	CACHE STRING "Flags used by the C++ compiler during UndefinedBehaviourSanitizer builds."
 	FORCE)
 
-add_subdirectory(lib/)
-add_subdirectory(use_case/)
+add_subdirectory(lib)
+add_subdirectory(use_case)
 
 if(ENABLE_TEST)
 	enable_testing()
@@ -91,9 +91,11 @@ if(ENABLE_PERFORMANCE)
 	add_subdirectory(performance/)
 endif()
 
-target_compile_options(EventBus PRIVATE
+if(NOT MSVC)
+	target_compile_options(EventBus PRIVATE
 	-Wall -pedantic
 	-Wnon-virtual-dtor
 	-Werror
 	-Wno-error=deprecated-declarations
 	)
+endif()

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -10,7 +10,7 @@ project(EventBus
 	)
 
 # Dependencies
-# No dependencies for EventBus yay!
+find_package(Threads)
 
 # Introduce variables:
 # * CMAKE_INSTALL_LIBDIR
@@ -18,7 +18,6 @@ project(EventBus
 # * CMAKE_INSTALL_INCLUDEDIR
 include(GNUInstallDirs)
 include(cmake/InstallHelp.cmake)
-
 
 # Layout. This works for all platforms:
 #   * <prefix>/lib*/cmake/<PROJECT-NAME>
@@ -71,6 +70,7 @@ target_include_directories(EventBus PUBLIC
 	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/>
 	$<INSTALL_INTERFACE:include/>
 	)
+target_link_libraries(EventBus ${CMAKE_THREAD_LIBS_INIT})
 
 # Add definitions for targets
 # Values:

--- a/lib/src/dexode/EventBus.cpp
+++ b/lib/src/dexode/EventBus.cpp
@@ -3,6 +3,8 @@
 //
 #include "EventBus.hpp"
 
+#include <iterator>
+
 namespace dexode
 {
 
@@ -30,7 +32,7 @@ std::size_t EventBus::processLimit(const std::size_t limit)
 
 	{
 		std::lock_guard writeGuard{_mutexStreams};
-		if(not _eventStreams.empty())
+		if(!_eventStreams.empty())
 		{
 			// If anything was added then we need to add those elements
 			std::move(_eventStreams.begin(), _eventStreams.end(), std::back_inserter(eventStreams));
@@ -70,7 +72,7 @@ eventbus::stream::EventStream* EventBus::findStream(
 void EventBus::unlistenAll(const std::uint32_t listenerID)
 {
 	std::shared_lock readGuard{_mutexStreams};
-	for(auto& eventStream : _eventToStream)
+	for(const auto& eventStream : _eventToStream)
 	{
 		eventStream.second->removeListener(listenerID);
 	}
@@ -120,7 +122,7 @@ eventbus::stream::EventStream* EventBus::listen(const std::uint32_t,
 void EventBus::unlisten(const std::uint32_t listenerID,
 						const eventbus::internal::event_id_t eventID)
 {
-	auto* eventStream = findStream(eventID);
+	eventbus::stream::EventStream* eventStream = findStream(eventID);
 	if(eventStream != nullptr)
 	{
 		eventStream->removeListener(listenerID);

--- a/lib/src/dexode/eventbus/stream/ProtectedEventStream.hpp
+++ b/lib/src/dexode/eventbus/stream/ProtectedEventStream.hpp
@@ -3,8 +3,9 @@
 #include <algorithm>
 #include <cassert>
 #include <functional>
-#include <vector>
+#include <iterator>
 #include <shared_mutex>
+#include <vector>
 
 #include "dexode/eventbus/stream/EventStream.hpp"
 


### PR DESCRIPTION
Since Microsoft seems to be pathologically incapable of adhering to external specifications I have "Fixed" a few things so that it builds with 2019.  I also needed to add threads to the lib dependencies, but in theory, all platforms should need that.    I am concerned about.  I am not sure what `-Wnon-virtual-dtor` is equivalent to on Windows.  I assume you are adding that to make sure strange stuff doesn't happen with inheritance? Let me know and I can clean this up further. 