### PR TITLE
Include missing header in ProtectedEventStream.hpp

### DIFF
--- a/lib/src/dexode/eventbus/stream/ProtectedEventStream.hpp
+++ b/lib/src/dexode/eventbus/stream/ProtectedEventStream.hpp
@@ -4,6 +4,7 @@
 #include <cassert>
 #include <functional>
 #include <iterator>
+#include <mutex>
 #include <shared_mutex>
 #include <vector>
 


### PR DESCRIPTION
Fixes build with Clang + libc++ from LLVM 18 due to undefined `std::lock_guard`